### PR TITLE
Adding current queue metrics page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,20 @@
 # connect-api-express
-Examples of using the Amazon Connect API with Node and Express
+An Express website that shows how to use the Amazon Connect API to interact with a Connect instance.
 
-Fill in your Connect instance id at the top of the index.js and then do "node index.js" to run the site
+## Install and Configuration
+Assuming you already have Node and NPM installed:
+1. Clone this repo
+2. Run "npm install"
+3. Update the values in instanceConfig.js with your Connect instance id and Queue ARN's
+4. Run "node index.js" and navigate to http://localhost:3000
+
+## API methods covered
+The website demonstrates using:
+1. listUsers
+2. describeUser
+3. updateContactAttributes
+4. getCurrentMetricData
+
+For a full reference to the Connect API see: https://docs.aws.amazon.com/connect/latest/APIReference/Welcome.html
+
+For a reference for the AWS JavaScript SDK, including Connect see: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Connect.html

--- a/instanceConfig.js
+++ b/instanceConfig.js
@@ -1,0 +1,7 @@
+const connectInstanceId = "yourConnectInstanceId";
+const connectQArns = ["qArn1", "qAnr2"];
+
+module.exports = {
+  connectInstanceId: connectInstanceId,
+  connectQArns: connectQArns
+};

--- a/public/css/base.css
+++ b/public/css/base.css
@@ -1,5 +1,4 @@
 /* source: https://designshack.net/articles/css/5-simple-and-practical-css-list-styles-you-can-copy-and-paste/ */
-@import "compass/css3";
 
 div {
   width: 200px;

--- a/public/js/currentMetrics.js
+++ b/public/js/currentMetrics.js
@@ -1,0 +1,4 @@
+console.log("script loaded");
+setTimeout(function() {
+  window.location.reload();
+}, 2000);

--- a/qMetrics.js
+++ b/qMetrics.js
@@ -1,0 +1,50 @@
+const metricsList = [
+  {
+    Name: "AGENTS_AVAILABLE",
+    Unit: "COUNT"
+  },
+  {
+    Name: "AGENTS_ONLINE",
+    Unit: "COUNT"
+  },
+  {
+    Name: "AGENTS_ON_CALL",
+    Unit: "COUNT"
+  },
+  {
+    Name: "AGENTS_ONLINE",
+    Unit: "COUNT"
+  },
+  {
+    Name: "AGENTS_STAFFED",
+    Unit: "COUNT"
+  },
+  {
+    Name: "AGENTS_AFTER_CONTACT_WORK",
+    Unit: "COUNT"
+  },
+  {
+    Name: "AGENTS_NON_PRODUCTIVE",
+    Unit: "COUNT"
+  },
+  {
+    Name: "AGENTS_ERROR",
+    Unit: "COUNT"
+  },
+  {
+    Name: "CONTACTS_IN_QUEUE",
+    Unit: "COUNT"
+  },
+  {
+    Name: "OLDEST_CONTACT_AGE",
+    Unit: "SECONDS"
+  },
+  {
+    Name: "CONTACTS_SCHEDULED",
+    Unit: "COUNT"
+  }
+];
+
+module.exports = {
+  metricsList: metricsList
+};

--- a/views/currentMetrics.pug
+++ b/views/currentMetrics.pug
@@ -1,0 +1,25 @@
+html
+  head
+    title= title
+    link(rel="stylesheet" href="css/base.css")
+  body
+    h3
+      = "Goto: "
+      a(href="updateAttributes") Update Attributes
+    h3
+      = "Goto: "
+      a(href="../") Users
+    h2= "Current Queue Metrics in my Connect Instance"
+    i= "Last updated at " + new Date().toLocaleString()
+    br
+    br
+    ul
+      each queue in metricResults
+        li
+          b= "Queue " + queue.Dimensions.Queue.Id
+          br
+          each metric in queue.Collections
+            span= metric.Value + " " + metric.Metric.Name
+            br
+          br
+  script(src='/js/currentMetrics.js') 

--- a/views/index.pug
+++ b/views/index.pug
@@ -6,6 +6,9 @@ html
     h3
       = "Goto: "
       a(href="updateAttributes") Update Attributes
+    h3
+      = "Goto: "
+      a(href="currentMetrics") Current Queue Metrics
     h2= "Users in my Connect Instance (" + dataList.length + ")"
     ul
       each val in dataList

--- a/views/updateAttributes.pug
+++ b/views/updateAttributes.pug
@@ -5,6 +5,9 @@ html
   body
     h3
       = "Goto: "
+      a(href="currentMetrics") Current Queue Metrics
+    h3
+      = "Goto: "
       a(href="../") Users
     h2= "Update Contact Attributes"
     form(method='POST' action='/submit-updateAttributes')


### PR DESCRIPTION
Added a new page that reloads every 2 seconds and shows the current metrics for all queues. Externalized the Connect instance settings